### PR TITLE
Add an RSS feed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ POST_HTMLS=$(patsubst content/posts/%.md,generated/public/posts/%.html,$(POST_MD
 SOURCE_POST_ASSETS=$(shell find content/posts/assets -type f ! -name '.*')
 TARGET_POST_ASSETS=$(patsubst content/%,generated/public/%,$(SOURCE_POST_ASSETS))
 
-all: pandoc-prereqs $(POST_HTMLS) $(TARGET_POST_ASSETS) generated/public/index.html generated/public/main.css generated/public/sitemap.xml
+all: pandoc-prereqs $(POST_HTMLS) $(TARGET_POST_ASSETS) generated/public/index.html generated/public/main.css generated/public/sitemap.xml generated/public/rss.xml
 
 pandoc-prereqs: generated/public/pandoc-highlight.css
 
@@ -59,6 +59,12 @@ generated/public/sitemap.xml: $(POST_MDS) transform/render_sitemap.rb .tool-vers
 	@mkdir -p $(dir $@)
 	@cd transform && \
 		bundle exec ruby render_sitemap.rb $(WORKING_DIR)/content/posts $(WORKING_DIR)/$@
+
+generated/public/rss.xml: $(POST_MDS) transform/render_rss.rb .tool-versions
+	@echo "Generating $@"
+	@mkdir -p $(dir $@)
+	@cd transform && \
+		bundle exec ruby render_rss.rb $(WORKING_DIR)/content/posts $(WORKING_DIR)/$@
 
 clean:
 	@echo "Cleaning generated files"

--- a/transform/render_rss.rb
+++ b/transform/render_rss.rb
@@ -1,0 +1,32 @@
+require "nokogiri"
+require "date"
+
+# render an RSS feed from all post sources (markdown files)
+
+DOMAIN = "https://simplexity.quest"
+TARGET = "../generated/public/rss.xml"
+TITLE = "Simplexity Quest"
+
+def git_mtime(path)
+  DateTime.parse(%x(git log -1 --pretty="format:%ci" #{path}).strip)
+end
+
+Nokogiri::XML::Builder.new(encoding: "UTF-8") do |xml|
+  xml.rss(version: "2.0") {
+    xml.channel {
+      xml.title TITLE
+      xml.link(DOMAIN + "/")
+      xml.description TITLE
+      latest_post = Dir.glob("../content/posts/**/*.md").map { |path| git_mtime(path) }.max
+      xml.pubDate latest_post.iso8601
+      Dir.glob("../content/posts/*.md").each do |path|
+        xml.item {
+          xml.link "#{DOMAIN}/posts/#{File.basename(path, ".md")}.html"
+          xml.pubDate git_mtime(path).iso8601
+        }
+      end
+    }
+  }
+end.to_xml.tap do |xml|
+  File.write(TARGET, xml)
+end


### PR DESCRIPTION
It's all well and good to refresh people's homepages, but syndication rules supreme.

This is almost the absolute minimum required to pass as RSS, but it means I'll get your posts in `newsboat` in the future without worrying about missing out.

```xml
<?xml version="1.0" encoding="UTF-8"?>
<rss version="2.0">
  <channel>
    <title>Simplexity Quest</title>
    <link>https://simplexity.quest/</link>
    <description>Simplexity Quest</description>
    <pubDate>2023-10-21T14:26:21-04:00</pubDate>
    <item>
      <link>https://simplexity.quest/posts/2023-08-29-emergent-engineering.html</link>
      <pubDate>2023-10-18T18:36:23-04:00</pubDate>
    </item>
    <item>
      <link>https://simplexity.quest/posts/2023-10-15-framework-13-1-year.html</link>
      <pubDate>2023-10-21T14:26:21-04:00</pubDate>
    </item>
  </channel>
</rss>
```